### PR TITLE
Add missing config for s3 storage (#96)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -8,7 +8,7 @@
   "invite_code": "top-sekrit",
 
   "storage_region": "eu-central-1",
-
+  "storage_endpoint": "http://localhost:4572",
   "storage_bucket": "my_spacedeck_bucket",
   "storage_cdn": "/storage",
   "storage_local_path": "./storage",


### PR DESCRIPTION
This var `storage_endpoint` will be read and used at https://github.com/spacedeck/spacedeck-open/blob/3eb99d2635973d0ae9d44bc74e4325a8820925b1/helpers/uploader.js#L14